### PR TITLE
payment experation date is required and fits validation

### DIFF
--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Bangazon.Models.ViewModels;
 
 namespace Bangazon.Controllers
 {
@@ -49,11 +50,17 @@ namespace Bangazon.Controllers
         // POST: PaymentTypes/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Create(PaymentType paymentType)
+        public async Task<ActionResult> Create(PaymentTypeViewModel paymentTypeViewModel)
         {
-            if(!ModelState.IsValid)
+            if (!ModelState.IsValid)
             {
-                return View(paymentType);
+                return View(new PaymentType 
+                {
+                    DateCreated = DateTime.Now,
+                    Description = paymentTypeViewModel.Description,
+                    AccountNumber = paymentTypeViewModel.AccountNumber,
+                    ExpirationDate = paymentTypeViewModel.ExpirationDate
+                });
             }
 
             try
@@ -62,19 +69,17 @@ namespace Bangazon.Controllers
 
                 var paymentTypeInstance = new PaymentType
                 {
-                    Description = paymentType.Description,
-                    AccountNumber = paymentType.AccountNumber,
+                    DateCreated = DateTime.Now,
+                    Description = paymentTypeViewModel.Description,
+                    AccountNumber = paymentTypeViewModel.AccountNumber,
+                    ExpirationDate = paymentTypeViewModel.ExpirationDate
                 };
-                    if (paymentType.ExpirationDate < DateTime.Now)
-                    {
-                        paymentTypeInstance.ExpirationDate = paymentType.ExpirationDate;
-                    }
 
                 paymentTypeInstance.UserId = user.Id;
 
-
                 _context.PaymentType.Add(paymentTypeInstance);
                 await _context.SaveChangesAsync();
+
 
                 return RedirectToAction(nameof(Index));
             }

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -51,6 +51,11 @@ namespace Bangazon.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Create(PaymentType paymentType)
         {
+            if(!ModelState.IsValid)
+            {
+                return View(paymentType);
+            }
+
             try
             {
                 var user = await GetCurrentUserAsync();
@@ -60,6 +65,10 @@ namespace Bangazon.Controllers
                     Description = paymentType.Description,
                     AccountNumber = paymentType.AccountNumber,
                 };
+                    if (paymentType.ExpirationDate < DateTime.Now)
+                    {
+                        paymentTypeInstance.ExpirationDate = paymentType.ExpirationDate;
+                    }
 
                 paymentTypeInstance.UserId = user.Id;
 

--- a/Bangazon/Data/ApplicationDbContext.cs
+++ b/Bangazon/Data/ApplicationDbContext.cs
@@ -69,14 +69,16 @@ namespace Bangazon.Data {
                     PaymentTypeId = 1,
                     UserId = user.Id,
                     Description = "American Express",
-                    AccountNumber = "86753095551212"
+                    AccountNumber = "86753095551212",
+                    ExpirationDate = new DateTime (2024, 08, 30)
                 },
                 new PaymentType()
                 {
                     PaymentTypeId = 2,
                     UserId = user.Id,
                     Description = "Discover",
-                    AccountNumber = "4102948572991"
+                    AccountNumber = "4102948572991",
+                    ExpirationDate = new DateTime(2020, 02, 29)
                 }
             );
 

--- a/Bangazon/Migrations/20200428154416_DatabaseTables.Designer.cs
+++ b/Bangazon/Migrations/20200428154416_DatabaseTables.Designer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bangazon.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20200424182124_BangazonTables")]
-    partial class BangazonTables
+    [Migration("20200428154416_DatabaseTables")]
+    partial class DatabaseTables
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -102,7 +102,7 @@ namespace Bangazon.Migrations
                         {
                             Id = "00000000-ffff-ffff-ffff-ffffffffffff",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "de03f20c-b4ed-476c-8ba8-7e742cb01483",
+                            ConcurrencyStamp = "48416c18-9253-49c1-beb7-5fbac5aaebe7",
                             Email = "admin@admin.com",
                             EmailConfirmed = true,
                             FirstName = "Admina",
@@ -110,7 +110,7 @@ namespace Bangazon.Migrations
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMIN@ADMIN.COM",
                             NormalizedUserName = "ADMIN@ADMIN.COM",
-                            PasswordHash = "AQAAAAEAACcQAAAAEAgyidTi6zvoAC79Eo35NRprpQLyvnXVv010bMwm+ICCthHmWyb0UicMzjsX3VTCXg==",
+                            PasswordHash = "AQAAAAEAACcQAAAAEGzWFcph/DK0XgM1vwZ/S95zIyosJwW6PQZt+4z7+wly0e0q3hua2GTzlNlta7PxIg==",
                             PhoneNumberConfirmed = false,
                             SecurityStamp = "7f434309-a4d9-48e9-9ebb-8803db794577",
                             StreetAddress = "123 Infinity Way",
@@ -216,6 +216,9 @@ namespace Bangazon.Migrations
                         .HasColumnType("nvarchar(55)")
                         .HasMaxLength(55);
 
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
@@ -233,6 +236,7 @@ namespace Bangazon.Migrations
                             AccountNumber = "86753095551212",
                             DateCreated = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Description = "American Express",
+                            ExpirationDate = new DateTime(2024, 8, 30, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             UserId = "00000000-ffff-ffff-ffff-ffffffffffff"
                         },
                         new
@@ -241,6 +245,7 @@ namespace Bangazon.Migrations
                             AccountNumber = "4102948572991",
                             DateCreated = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Description = "Discover",
+                            ExpirationDate = new DateTime(2020, 2, 29, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             UserId = "00000000-ffff-ffff-ffff-ffffffffffff"
                         });
                 });

--- a/Bangazon/Migrations/20200428154416_DatabaseTables.cs
+++ b/Bangazon/Migrations/20200428154416_DatabaseTables.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Bangazon.Migrations
 {
-    public partial class BangazonTables : Migration
+    public partial class DatabaseTables : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -175,6 +175,7 @@ namespace Bangazon.Migrations
                     PaymentTypeId = table.Column<int>(nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "GETDATE()"),
+                    ExpirationDate = table.Column<DateTime>(nullable: false),
                     Description = table.Column<string>(maxLength: 55, nullable: false),
                     AccountNumber = table.Column<string>(maxLength: 20, nullable: false),
                     UserId = table.Column<string>(nullable: false)
@@ -281,7 +282,7 @@ namespace Bangazon.Migrations
             migrationBuilder.InsertData(
                 table: "AspNetUsers",
                 columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "FirstName", "LastName", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "StreetAddress", "TwoFactorEnabled", "UserName" },
-                values: new object[] { "00000000-ffff-ffff-ffff-ffffffffffff", 0, "de03f20c-b4ed-476c-8ba8-7e742cb01483", "admin@admin.com", true, "Admina", "Straytor", false, null, "ADMIN@ADMIN.COM", "ADMIN@ADMIN.COM", "AQAAAAEAACcQAAAAEAgyidTi6zvoAC79Eo35NRprpQLyvnXVv010bMwm+ICCthHmWyb0UicMzjsX3VTCXg==", null, false, "7f434309-a4d9-48e9-9ebb-8803db794577", "123 Infinity Way", false, "admin@admin.com" });
+                values: new object[] { "00000000-ffff-ffff-ffff-ffffffffffff", 0, "48416c18-9253-49c1-beb7-5fbac5aaebe7", "admin@admin.com", true, "Admina", "Straytor", false, null, "ADMIN@ADMIN.COM", "ADMIN@ADMIN.COM", "AQAAAAEAACcQAAAAEGzWFcph/DK0XgM1vwZ/S95zIyosJwW6PQZt+4z7+wly0e0q3hua2GTzlNlta7PxIg==", null, false, "7f434309-a4d9-48e9-9ebb-8803db794577", "123 Infinity Way", false, "admin@admin.com" });
 
             migrationBuilder.InsertData(
                 table: "ProductType",
@@ -307,11 +308,11 @@ namespace Bangazon.Migrations
 
             migrationBuilder.InsertData(
                 table: "PaymentType",
-                columns: new[] { "PaymentTypeId", "AccountNumber", "Description", "UserId" },
+                columns: new[] { "PaymentTypeId", "AccountNumber", "Description", "ExpirationDate", "UserId" },
                 values: new object[,]
                 {
-                    { 1, "86753095551212", "American Express", "00000000-ffff-ffff-ffff-ffffffffffff" },
-                    { 2, "4102948572991", "Discover", "00000000-ffff-ffff-ffff-ffffffffffff" }
+                    { 1, "86753095551212", "American Express", new DateTime(2024, 8, 30, 0, 0, 0, 0, DateTimeKind.Unspecified), "00000000-ffff-ffff-ffff-ffffffffffff" },
+                    { 2, "4102948572991", "Discover", new DateTime(2020, 2, 29, 0, 0, 0, 0, DateTimeKind.Unspecified), "00000000-ffff-ffff-ffff-ffffffffffff" }
                 });
 
             migrationBuilder.InsertData(

--- a/Bangazon/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Bangazon/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -100,7 +100,7 @@ namespace Bangazon.Migrations
                         {
                             Id = "00000000-ffff-ffff-ffff-ffffffffffff",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "de03f20c-b4ed-476c-8ba8-7e742cb01483",
+                            ConcurrencyStamp = "48416c18-9253-49c1-beb7-5fbac5aaebe7",
                             Email = "admin@admin.com",
                             EmailConfirmed = true,
                             FirstName = "Admina",
@@ -108,7 +108,7 @@ namespace Bangazon.Migrations
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMIN@ADMIN.COM",
                             NormalizedUserName = "ADMIN@ADMIN.COM",
-                            PasswordHash = "AQAAAAEAACcQAAAAEAgyidTi6zvoAC79Eo35NRprpQLyvnXVv010bMwm+ICCthHmWyb0UicMzjsX3VTCXg==",
+                            PasswordHash = "AQAAAAEAACcQAAAAEGzWFcph/DK0XgM1vwZ/S95zIyosJwW6PQZt+4z7+wly0e0q3hua2GTzlNlta7PxIg==",
                             PhoneNumberConfirmed = false,
                             SecurityStamp = "7f434309-a4d9-48e9-9ebb-8803db794577",
                             StreetAddress = "123 Infinity Way",
@@ -214,6 +214,9 @@ namespace Bangazon.Migrations
                         .HasColumnType("nvarchar(55)")
                         .HasMaxLength(55);
 
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
@@ -231,6 +234,7 @@ namespace Bangazon.Migrations
                             AccountNumber = "86753095551212",
                             DateCreated = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Description = "American Express",
+                            ExpirationDate = new DateTime(2024, 8, 30, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             UserId = "00000000-ffff-ffff-ffff-ffffffffffff"
                         },
                         new
@@ -239,6 +243,7 @@ namespace Bangazon.Migrations
                             AccountNumber = "4102948572991",
                             DateCreated = new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Description = "Discover",
+                            ExpirationDate = new DateTime(2020, 2, 29, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             UserId = "00000000-ffff-ffff-ffff-ffffffffffff"
                         });
                 });

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -19,7 +19,6 @@ namespace Bangazon.Models
 
     [Required(ErrorMessage = "Expiration date is required")]
     [DataType(DataType.Date)]
-    [CheckDateRange]
     public DateTime ExpirationDate { get; set; }
 
     [Required]
@@ -37,20 +36,6 @@ namespace Bangazon.Models
     public ApplicationUser User { get; set; }
 
     public ICollection<Order> Orders { get; set; }
-
-    }
-    public class CheckDateRangeAttribute : ValidationAttribute
-    {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            DateTime dt = (DateTime)value;
-            if (dt >= DateTime.UtcNow)
-            {
-                return ValidationResult.Success;
-            }
-
-            return new ValidationResult(ErrorMessage ?? "Expiration date cannot be in the past");
-        }
 
     }
 }

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -16,6 +16,12 @@ namespace Bangazon.Models
     [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
     public DateTime DateCreated { get; set; }
 
+
+    [Required(ErrorMessage = "Expiration date is required")]
+    [DataType(DataType.Date)]
+    [CheckDateRange]
+    public DateTime ExpirationDate { get; set; }
+
     [Required]
     [StringLength(55)]
     public string Description { get; set; }
@@ -31,5 +37,20 @@ namespace Bangazon.Models
     public ApplicationUser User { get; set; }
 
     public ICollection<Order> Orders { get; set; }
-  }
+
+    }
+    public class CheckDateRangeAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            DateTime dt = (DateTime)value;
+            if (dt >= DateTime.UtcNow)
+            {
+                return ValidationResult.Success;
+            }
+
+            return new ValidationResult(ErrorMessage ?? "Expiration date cannot be in the past");
+        }
+
+    }
 }

--- a/Bangazon/Models/ViewModels/PaymentTypeViewModel.cs
+++ b/Bangazon/Models/ViewModels/PaymentTypeViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Bangazon.Models.ViewModels
+{
+    public class PaymentTypeViewModel
+    {
+        [Key]
+        public int PaymentTypeId { get; set; }
+
+        [Required(ErrorMessage = "Expiration date is required")]
+        [DataType(DataType.Date)]
+        [CheckDateRange]
+        public DateTime ExpirationDate { get; set; }
+
+        [Required]
+        [StringLength(55)]
+        public string Description { get; set; }
+
+        [Required]
+        [StringLength(20)]
+        public string AccountNumber { get; set; }
+    }
+    public class CheckDateRangeAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            DateTime dt = (DateTime)value;
+            if (dt >= DateTime.UtcNow)
+            {
+                return ValidationResult.Success;
+            }
+
+            return new ValidationResult(ErrorMessage ?? "Expiration date cannot be in the past");
+        }
+
+    }
+}

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -21,6 +21,11 @@
                 <input asp-for="AccountNumber" class="form-control" />
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
+            <div class="form-group date">
+                <label asp-for="ExpirationDate" class="control-label">Expiration Date</label>
+                <input asp-for="ExpirationDate" class="form-control" />
+                <span asp-validation-for="ExpirationDate" class="text-danger"></span>
+            </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -42,9 +42,6 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="Index">Products</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Product Types</a>
-                        </li>
                         @if (SignInManager.IsSignedIn(User))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
# Description

Expiration date added to payment as a required field and must be today's date or later.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Testing Instructions

You will need to delete your database and migrations folder, run a new Add-Migration as well as an Update-Database so that the expiration date column will be added to the payment type table.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
